### PR TITLE
fix(fe): fix atom

### DIFF
--- a/frontend/src/api/atom.js
+++ b/frontend/src/api/atom.js
@@ -1,6 +1,21 @@
 import { atom } from "recoil";
-
 export const userDataState = atom({
   key: "userDataState",
   default: null,
+  effects_UNSTABLE: [
+    ({ setSelf, onSet }) => {
+      // 초기값을 localStorage에서 가져오기
+      const saved = localStorage.getItem("userDataState");
+      if (saved != null) setSelf(JSON.parse(saved));
+
+      // 값이 바뀔 때마다 localStorage에 저장
+      onSet((newValue, _, isReset) => {
+        if (isReset || newValue == null) {
+          localStorage.removeItem("userDataState");
+        } else {
+          localStorage.setItem("userDataState", JSON.stringify(newValue));
+        }
+      });
+    },
+  ],
 });


### PR DESCRIPTION
atom의 userDataState를 localStorage와 연동합니다.
Recoil의 atom을 localStorage와 연동하면, 새로고침/경로 이동 후에도 값이 유지됩니다.